### PR TITLE
Ajoute un laboratoire FortiSASE automatisé

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.venv/
+out/
+__pycache__/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,41 @@
-# FortiSASE_Labs
+# FortiSASE Labs
+
+Ce dépôt fournit un laboratoire FortiSASE entièrement automatisé pour tester des scénarios Secure Access Service Edge (SASE) avec une topologie complète, des scripts d'initialisation et des configurations reproductibles. Le laboratoire s'appuie sur Ansible pour orchestrer les équipements virtuels et sur des scripts Bash pour préparer l'environnement, déployer la topologie et appliquer les configurations réseau et sécurité.
+
+## Contenu
+
+- `docs/` – Documentation fonctionnelle et technique du laboratoire.
+- `topology/` – Description formelle de la topologie et des liens.
+- `templates/` – Modèles de configuration pour les différents rôles (hub, branche, accès distant, sécurité cloud).
+- `ansible/` – Inventaire, variables et playbooks pour automatiser l'initialisation et la configuration.
+- `scripts/` – Scripts shell pour préparer l'environnement, lancer Ansible et nettoyer le lab.
+
+## Prérequis
+
+1. Linux/macOS avec Bash, Python 3.9+, Ansible 2.14+, OpenSSH et `pipx`.
+2. Accès aux images virtuelles FortiGate/FortiSASE ou appliances équivalentes via un hyperviseur (EVE-NG, GNS3, KVM) et connectivité aux interfaces de gestion.
+3. Fichiers de licence valides pour les images Fortinet utilisées.
+4. Accès réseau entre la machine d'orchestration et tous les équipements de lab.
+
+## Démarrage rapide
+
+1. **Préparer l'environnement**
+   ```bash
+   ./scripts/init_lab.sh
+   ```
+2. **Appliquer la configuration de base**
+   ```bash
+   ./scripts/configure_hub.sh
+   ./scripts/configure_branch.sh
+   ./scripts/configure_sase.sh
+   ```
+3. **Vérifier l'état**
+   ```bash
+   ansible -i ansible/inventory.ini all -m ping
+   ```
+4. **Nettoyer** (optionnel)
+   ```bash
+   ./scripts/cleanup.sh
+   ```
+
+Consultez `docs/overview.md` et `docs/topology.md` pour la description détaillée du scénario, de la topologie et des flux de trafic.

--- a/ansible/group_vars/branch1.yml
+++ b/ansible/group_vars/branch1.yml
@@ -1,0 +1,16 @@
+hostname: BR1-FGT
+wan_interface: port2
+lan_interface:
+  name: port3
+  ip: 192.168.10.1
+  mask: 255.255.255.0
+  dhcp:
+    enable: true
+    range_start: 192.168.10.10
+    range_end: 192.168.10.200
+hub_peer:
+  ip: 172.16.0.1
+  pre_shared_key: Fortinet123!
+ztna_tags:
+  - branch
+  - trusted

--- a/ansible/group_vars/branch2.yml
+++ b/ansible/group_vars/branch2.yml
@@ -1,0 +1,16 @@
+hostname: BR2-FGT
+wan_interface: port2
+lan_interface:
+  name: port3
+  ip: 192.168.20.1
+  mask: 255.255.255.0
+  dhcp:
+    enable: true
+    range_start: 192.168.20.10
+    range_end: 192.168.20.200
+hub_peer:
+  ip: 172.16.0.1
+  pre_shared_key: Fortinet123!
+ztna_tags:
+  - branch
+  - ot

--- a/ansible/group_vars/hub.yml
+++ b/ansible/group_vars/hub.yml
@@ -1,0 +1,55 @@
+hostname: HUB-FGT
+sdwan_members:
+  - interface: port2
+    zone: OVERLAY
+    seq_num: 10
+lan_interfaces:
+  - name: port3
+    ip: 192.168.0.1
+    mask: 255.255.255.0
+    dhcp:
+      enable: true
+      range_start: 192.168.0.50
+      range_end: 192.168.0.200
+vpn_peers:
+  - name: BR1
+    remote_ip: 172.16.0.11
+    pre_shared_key: Fortinet123!
+  - name: BR2
+    remote_ip: 172.16.0.12
+    pre_shared_key: Fortinet123!
+sase_overlay:
+  gateway: 172.16.0.254
+  interface: port2
+firewall_policies:
+  - firewall_policy:
+      name: Branches-to-LAN
+      srcintf:
+        - name: port2
+      dstintf:
+        - name: port3
+      srcaddr:
+        - name: branch_overlay
+      dstaddr:
+        - name: lan
+      service:
+        - name: ALL
+      action: accept
+      schedule: always
+      inspection_mode: flow
+  - firewall_policy:
+      name: Internet-via-SASE
+      srcintf:
+        - name: port3
+      dstintf:
+        - name: port2
+      srcaddr:
+        - name: lan
+        - name: branch_overlay
+      dstaddr:
+        - name: sase
+      service:
+        - name: ALL
+      action: accept
+      schedule: always
+      inspection_profile: default

--- a/ansible/group_vars/iam.yml
+++ b/ansible/group_vars/iam.yml
@@ -1,0 +1,17 @@
+hostname: idm
+packages:
+  - freeradius
+  - strongswan
+  - openldap
+radius_clients:
+  - name: fortigate-hub
+    ip: 192.168.0.1
+    secret: radiussecret
+ldap_domain: dc=sase,dc=lab
+users:
+  - username: alice
+    password: Passw0rd!
+    groups: [teleworkers]
+  - username: bob
+    password: Passw0rd!
+    groups: [teleworkers]

--- a/ansible/group_vars/sase.yml
+++ b/ansible/group_vars/sase.yml
@@ -1,0 +1,23 @@
+api_base_url: https://api.fortisase.local
+ztna_portal:
+  name: RemotePortal
+  fqdn: portal.sase.lab
+  authentication:
+    - type: radius
+      server: 192.168.100.10
+      secret: radiussecret
+    - type: saml
+      idp_metadata_url: https://idm.sase.lab/saml/metadata
+access_policies:
+  - name: Allow-Trusted
+    users: [group-teleworkers]
+    applications: [Office365, Salesforce]
+    action: allow
+    security_profiles:
+      av_profile: default
+      webfilter: default
+      ips_sensor: default
+  - name: Deny-Unknown
+    users: [any]
+    applications: [any]
+    action: deny

--- a/ansible/inventory.ini
+++ b/ansible/inventory.ini
@@ -1,0 +1,15 @@
+[hub]
+hub ansible_host=10.10.10.10 ansible_user=admin ansible_password=changeme ansible_network_os=fortinet.fortios.fortios
+
+[branches]
+branch1 ansible_host=10.10.11.10 ansible_user=admin ansible_password=changeme ansible_network_os=fortinet.fortios.fortios
+branch2 ansible_host=10.10.12.10 ansible_user=admin ansible_password=changeme ansible_network_os=fortinet.fortios.fortios
+
+[sase]
+fortisase_pop ansible_host=100.64.0.10 ansible_user=apiuser ansible_password=changeme ansible_network_os=fortinet.fortisase.fortisase
+
+[iam]
+iam ansible_host=192.168.100.10 ansible_user=ubuntu ansible_ssh_private_key_file=~/.ssh/id_rsa
+
+[all:vars]
+ansible_python_interpreter=/usr/bin/python3

--- a/ansible/playbooks/configure.yml
+++ b/ansible/playbooks/configure.yml
@@ -1,0 +1,87 @@
+---
+- name: Configuration avancée FortiGate Hub
+  hosts: hub
+  gather_facts: no
+  collections:
+    - fortinet.fortios
+  tasks:
+    - name: Créer la zone SD-WAN
+      fortios_system_sdwan:
+        vdom: root
+        system_sdwan:
+          status: enable
+          members: "{{ sdwan_members }}"
+
+    - name: Définir les peers VPN
+      fortios_vpn_ipsec_phase1_interface:
+        vdom: root
+        state: present
+        vpn_ipsec_phase1_interface:
+          name: "{{ item.name }}"
+          interface: port2
+          remote_gw: "{{ item.remote_ip }}"
+          psksecret: "{{ item.pre_shared_key }}"
+          proposal: aes256-sha256
+      loop: "{{ vpn_peers }}"
+
+    - name: Configurer la route par défaut vers le POP SASE
+      when: sase_overlay is defined
+      fortios_router_static:
+        vdom: root
+        state: present
+        router_static:
+          dst: 0.0.0.0/0
+          gateway: "{{ sase_overlay.gateway }}"
+          device: "{{ sase_overlay.interface }}"
+
+    - name: Créer les politiques firewall
+      fortios_firewall_policy:
+        vdom: root
+        state: present
+        firewall_policy: "{{ item.firewall_policy }}"
+      loop: "{{ firewall_policies }}"
+
+- name: Configuration FortiGate Branches
+  hosts: branches
+  gather_facts: no
+  collections:
+    - fortinet.fortios
+  tasks:
+    - name: Configurer VPN vers hub
+      fortios_vpn_ipsec_phase1_interface:
+        vdom: root
+        state: present
+        vpn_ipsec_phase1_interface:
+          name: HUB
+          interface: "{{ wan_interface }}"
+          remote_gw: "{{ hub_peer.ip }}"
+          psksecret: "{{ hub_peer.pre_shared_key }}"
+          proposal: aes256-sha256
+
+    - name: Déployer les tags ZTNA
+      fortios_ztna_tag:
+        vdom: root
+        state: present
+        ztna_tag:
+          name: "{{ item }}"
+      loop: "{{ ztna_tags }}"
+
+- name: Configuration du POP FortiSASE
+  hosts: sase
+  gather_facts: no
+  collections:
+    - fortinet.fortisase
+  tasks:
+    - name: Créer le portail ZTNA
+      fortisase_portal:
+        state: present
+        portal:
+          name: "{{ ztna_portal.name }}"
+          fqdn: "{{ ztna_portal.fqdn }}"
+          authentication: "{{ ztna_portal.authentication }}"
+
+    - name: Déployer les politiques d'accès
+      fortisase_access_policy:
+        state: present
+        access_policy: "{{ item }}"
+      loop: "{{ access_policies }}"

--- a/ansible/playbooks/init.yml
+++ b/ansible/playbooks/init.yml
@@ -1,0 +1,77 @@
+---
+- name: Initialisation des FortiGate
+  hosts: hub:branches
+  gather_facts: no
+  collections:
+    - fortinet.fortios
+  tasks:
+    - name: Définir l'hostname
+      fortios_system_global:
+        vdom: root
+        system_global:
+          hostname: "{{ hostname }}"
+
+    - name: Configurer l'interface LAN
+      fortios_system_interface:
+        vdom: root
+        state: present
+        system_interface:
+          name: "{{ item.name }}"
+          mode: static
+          ip: "{{ item.ip }} {{ item.mask }}"
+          allowaccess: ping https ssh
+      loop: "{{ [lan_interface] if lan_interface is defined else lan_interfaces }}"
+
+    - name: Activer DHCP sur les interfaces LAN
+      when: item.dhcp.enable | default(false)
+      fortios_system_dhcp_server:
+        vdom: root
+        state: present
+        system_dhcp_server:
+          interface: "{{ item.name }}"
+          ip_mode: range
+          default_gateway: "{{ item.ip }}"
+          netmask: "{{ item.mask }}"
+          ip_range:
+            - start_ip: "{{ item.dhcp.range_start }}"
+              end_ip: "{{ item.dhcp.range_end }}"
+      loop: "{{ [lan_interface] if lan_interface is defined else lan_interfaces }}"
+
+- name: Initialisation IAM
+  hosts: iam
+  become: yes
+  tasks:
+    - name: Installer les paquets requis
+      ansible.builtin.package:
+        name: "{{ packages }}"
+        state: present
+
+    - name: Créer les utilisateurs LDAP
+      community.general.ldap_entry:
+        dn: "uid={{ item.username }},ou=users,{{ ldap_domain }}"
+        objectClass:
+          - inetOrgPerson
+          - posixAccount
+          - top
+        attributes:
+          cn: "{{ item.username }}"
+          sn: "{{ item.username }}"
+          uidNumber: "{{ 1000 + loop.index }}"
+          gidNumber: 100
+          homeDirectory: "/home/{{ item.username }}"
+          userPassword: "{{ item.password }}"
+      loop: "{{ users }}"
+      ignore_errors: yes  # permet la relance idempotente
+
+    - name: Déclarer le client RADIUS FortiGate
+      ansible.builtin.template:
+        src: ../../templates/radius-clients.conf.j2
+        dest: /etc/freeradius/clients.d/fortigate.conf
+        mode: '0640'
+      notify: restart radius
+
+  handlers:
+    - name: restart radius
+      ansible.builtin.service:
+        name: freeradius
+        state: restarted

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,0 +1,35 @@
+# Vue d'ensemble du laboratoire FortiSASE
+
+Ce laboratoire reproduit un déploiement SASE typique comprenant :
+
+- Un siège (Hub) FortiGate assurant l'agrégation SD-WAN et les services UTM avancés.
+- Deux sites distants (Branch-1 et Branch-2) connectés via IPsec/SSL vers le hub avec basculement dynamique SD-WAN.
+- Une passerelle SASE cloud (FortiSASE POP) pour la sécurisation des utilisateurs nomades et l'accès Internet.
+- Un contrôleur d'authentification (FortiAuthenticator) pour la gestion des identités.
+- Un orchestrateur (cette machine) qui pilote la configuration via Ansible.
+
+Les cas d'usage couverts :
+
+1. **Accès sécurisé des sites distants** : Les branches utilisent SD-WAN avec application d'inspection NGFW, filtrage web et prévention des intrusions via le hub.
+2. **Accès utilisateur nomade** : Les clients VPN SSL se connectent au POP SASE, profitent du ZTNA et du contrôle applicatif.
+3. **Inspection du trafic Internet** : Redirection du trafic via le POP SASE avec politiques fondées sur l'identité et la posture.
+4. **Surveillance & reporting** : Collecte des logs vers FortiAnalyzer (optionnel) et supervision via FortiManager.
+
+## Flux opérationnels
+
+1. **Initialisation** : `scripts/init_lab.sh` installe les dépendances Python/Ansible, prépare les collections Fortinet Ansible et vérifie la connectivité aux équipements.
+2. **Provisioning** : `ansible/playbooks/init.yml` pousse la configuration de base (interfaces, VLAN, routes) sur tous les nœuds.
+3. **Configuration avancée** : `ansible/playbooks/configure.yml` applique les politiques de sécurité, SD-WAN, VPN, ZTNA et intégrations IAM.
+4. **Validation** : Des tests Ansible et des scripts `verify_*.yml` (à créer selon besoins) permettent de valider la posture.
+
+## Personnalisation
+
+- Ajoutez ou supprimez des branches en dupliquant les fichiers de variables dans `ansible/group_vars/`.
+- Mettez à jour les modèles de configuration dans `templates/` pour refléter vos exigences spécifiques (par exemple, plages IP, politiques).
+- Intégrez des outils supplémentaires (FortiAnalyzer, FortiManager) en complétant l'inventaire et les playbooks.
+
+## Ressources complémentaires
+
+- [Fortinet Ansible Galaxy Collection](https://galaxy.ansible.com/fortinet) pour la documentation des modules.
+- [Guides FortiSASE](https://docs.fortinet.com/product/fortisase) pour les meilleures pratiques de déploiement.
+- [ZTNA Design Guide](https://www.fortinet.com/resources) pour l'architecture Zero Trust.

--- a/docs/topology.md
+++ b/docs/topology.md
@@ -1,0 +1,60 @@
+# Topologie du laboratoire
+
+```
+                                      +---------------------+
+                                      |  FortiAnalyzer      |
+                                      |  (Optionnel)        |
+                                      +----------+----------+
+                                                 |
+                                                 |
+                        Internet/MPLS ---------- + -------------------------+
+                                                 |                           |
+                           +---------------------+---------------------+     |
+                           |         POP FortiSASE / ZTNA Gateway      |     |
+                           |  (inspection, CASB, SWG, ZTNA, RBI)       |     |
+                           +----------+----------------------+----------+     |
+                                      |                      |                |
+                                      |                      |                |
+                                VPN SSL Clients         IPsec overlay        |
+                                      |                      |                |
+                 +--------------------+              +-----+-------+          |
+                 |                                       |               +----+----+
+                 |                                   +---+---+           | Hub FG |
+         +-------+------+                            | Edge  |           | (HQ)   |
+         | Teleworker 1 |                            | CPE   |           +----+---+
+         +--------------+                            +---+---+                |
+                                                           |                 LAN
+                                                           |                  |
+                                                  +--------+--------+   +----+----+
+                                                  | Branch FortiGate|   | IAM/AD  |
+                                                  | (Branch-1)      |   | Server  |
+                                                  +--------+--------+   +---------+
+                                                           |
+                                                     LAN / WiFi
+
+                                                  +--------+--------+
+                                                  | Branch FortiGate|
+                                                  | (Branch-2)      |
+                                                  +--------+--------+
+                                                           |
+                                                     LAN / OT Zone
+```
+
+## Description des segments
+
+| Segment                | Adresse IP / VLAN            | Description                                                   |
+|------------------------|------------------------------|---------------------------------------------------------------|
+| Gestion Hub            | 10.10.10.0/24                | Interfaces de gestion FortiGate Hub                          |
+| Gestion Branch-1       | 10.10.11.0/24                | Accès admin Branch-1                                         |
+| Gestion Branch-2       | 10.10.12.0/24                | Accès admin Branch-2                                         |
+| Overlay SD-WAN         | 172.16.0.0/24                | Tunnel IPsec/SSL entre branches et hub                      |
+| LAN Hub                | 192.168.0.0/24               | LAN interne hub                                              |
+| LAN Branch-1           | 192.168.10.0/24              | LAN utilisateur branch-1                                    |
+| LAN Branch-2           | 192.168.20.0/24              | LAN utilisateur/OT branch-2                                 |
+| POP FortiSASE          | 100.64.0.0/24                | Interfaces logiques SASE                                    |
+| VPN SSL Clients        | 192.168.200.0/24             | Pool d'adresses clients nomades                             |
+| IAM/AD                 | 192.168.100.0/24             | Services d'identité et authentification                     |
+
+## Fichier de topologie
+
+Le fichier `topology/topology.yaml` contient la définition machine-par-machine des interfaces, réseaux et dépendances. Il peut être importé dans EVE-NG ou utilisé pour générer automatiquement des diagrammes via des outils comme NetBox ou draw.io (en le convertissant avec `netbox-importer`).

--- a/scripts/cleanup.sh
+++ b/scripts/cleanup.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+if [[ -d "$ROOT_DIR/.venv" ]]; then
+  echo "Suppression de l'environnement virtuel"
+  rm -rf "$ROOT_DIR/.venv"
+fi
+rm -rf "$ROOT_DIR/out"

--- a/scripts/configure_branch.sh
+++ b/scripts/configure_branch.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+source "$ROOT_DIR/.venv/bin/activate"
+ansible-playbook -i "$ROOT_DIR/ansible/inventory.ini" "$ROOT_DIR/ansible/playbooks/init.yml" --limit branches
+ansible-playbook -i "$ROOT_DIR/ansible/inventory.ini" "$ROOT_DIR/ansible/playbooks/configure.yml" --limit branches

--- a/scripts/configure_hub.sh
+++ b/scripts/configure_hub.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+source "$ROOT_DIR/.venv/bin/activate"
+ansible-playbook -i "$ROOT_DIR/ansible/inventory.ini" "$ROOT_DIR/ansible/playbooks/init.yml" --limit hub
+ansible-playbook -i "$ROOT_DIR/ansible/inventory.ini" "$ROOT_DIR/ansible/playbooks/configure.yml" --limit hub

--- a/scripts/configure_sase.sh
+++ b/scripts/configure_sase.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+source "$ROOT_DIR/.venv/bin/activate"
+ansible-playbook -i "$ROOT_DIR/ansible/inventory.ini" "$ROOT_DIR/ansible/playbooks/init.yml" --limit sase
+ansible-playbook -i "$ROOT_DIR/ansible/inventory.ini" "$ROOT_DIR/ansible/playbooks/configure.yml" --limit sase
+template_output="$ROOT_DIR/out/fortisase-config.yaml"
+mkdir -p "$(dirname "$template_output")"
+ansible localhost -c local -i localhost, -m template \
+  -e "@${ROOT_DIR}/ansible/group_vars/sase.yml" \
+  -a "src=${ROOT_DIR}/templates/sase-config.txt dest=${template_output}"
+echo "Configuration SASE générée: $template_output"

--- a/scripts/init_lab.sh
+++ b/scripts/init_lab.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+VENV_DIR="$ROOT_DIR/.venv"
+
+log() {
+  echo -e "[INIT] $*"
+}
+
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "Python3 est requis" >&2
+  exit 1
+fi
+
+if [[ ! -d "$VENV_DIR" ]]; then
+  log "Création de l'environnement virtuel"
+  python3 -m venv "$VENV_DIR"
+fi
+
+source "$VENV_DIR/bin/activate"
+
+log "Mise à jour pip et installation des dépendances"
+pip install --upgrade pip
+pip install ansible==8.4.0 ansible-lint fortinet-fortios==2.1.6
+
+log "Installation des collections Fortinet"
+ansible-galaxy collection install fortinet.fortios fortinet.fortisase community.general
+
+log "Vérification de la connectivité SSH/HTTPS"
+ansible -i "$ROOT_DIR/ansible/inventory.ini" all -m ping || {
+  log "Certaines cibles ne répondent pas au ping Ansible"
+}
+
+log "Initialisation terminée"

--- a/templates/branch-config.txt
+++ b/templates/branch-config.txt
@@ -1,0 +1,10 @@
+config system global
+    set hostname {{ hostname | default('BR-FGT') }}
+end
+
+config system interface
+    edit "port3"
+        set ip {{ lan_interface.ip }} {{ lan_interface.mask }}
+        set allowaccess ping https ssh
+    next
+end

--- a/templates/hub-config.txt
+++ b/templates/hub-config.txt
@@ -1,0 +1,10 @@
+config system global
+    set hostname {{ hostname | default('HUB-FGT') }}
+end
+
+config system interface
+    edit "port3"
+        set ip 192.168.0.1 255.255.255.0
+        set allowaccess ping https ssh
+    next
+end

--- a/templates/radius-clients.conf.j2
+++ b/templates/radius-clients.conf.j2
@@ -1,0 +1,7 @@
+{% for client in radius_clients %}
+client {{ client.name }} {
+  ipaddr = {{ client.ip }}
+  secret = {{ client.secret }}
+  require_message_authenticator = no
+}
+{% endfor %}

--- a/templates/sase-config.txt
+++ b/templates/sase-config.txt
@@ -1,0 +1,14 @@
+ztna-portal:
+  name: {{ ztna_portal.name }}
+  fqdn: {{ ztna_portal.fqdn }}
+  auth:
+{% for auth in ztna_portal.authentication %}
+    - type: {{ auth.type }}
+      target: {{ auth.server | default(auth.idp_metadata_url) }}
+{% endfor %}
+policies:
+{% for policy in access_policies %}
+  - name: {{ policy.name }}
+    action: {{ policy.action }}
+    applications: {{ policy.applications | join(',') }}
+{% endfor %}

--- a/topology/topology.yaml
+++ b/topology/topology.yaml
@@ -1,0 +1,80 @@
+nodes:
+  hub:
+    type: fortigate
+    mgmt_ip: 10.10.10.10
+    image: FortiGate-VM64
+    interfaces:
+      port1:
+        role: management
+        ip: 10.10.10.10/24
+        gateway: 10.10.10.1
+      port2:
+        role: wan1
+        ip: 172.16.0.1/24
+        description: SD-WAN overlay
+      port3:
+        role: lan
+        ip: 192.168.0.1/24
+        description: LAN Hub
+  branch1:
+    type: fortigate
+    mgmt_ip: 10.10.11.10
+    image: FortiGate-VM64
+    interfaces:
+      port1:
+        role: management
+        ip: 10.10.11.10/24
+        gateway: 10.10.11.1
+      port2:
+        role: wan1
+        ip: 172.16.0.11/24
+        description: Tunnel vers hub
+      port3:
+        role: lan
+        ip: 192.168.10.1/24
+        description: LAN Branch-1
+  branch2:
+    type: fortigate
+    mgmt_ip: 10.10.12.10
+    image: FortiGate-VM64
+    interfaces:
+      port1:
+        role: management
+        ip: 10.10.12.10/24
+        gateway: 10.10.12.1
+      port2:
+        role: wan1
+        ip: 172.16.0.12/24
+        description: Tunnel vers hub
+      port3:
+        role: lan
+        ip: 192.168.20.1/24
+        description: LAN Branch-2
+  fortisase_pop:
+    type: fortisase
+    mgmt_ip: 100.64.0.10
+    image: FortiSASE
+    interfaces:
+      port1:
+        role: internet
+        ip: dhcp
+        description: Sortie Internet
+      port2:
+        role: overlay
+        ip: 172.16.0.254/24
+        description: Terminaison overlay
+  iam:
+    type: linux
+    hostname: idm
+    mgmt_ip: 192.168.100.10
+    image: ubuntu-22.04
+    services:
+      - freeradius
+      - ldap
+links:
+  - nodes: [hub:port2, branch1:port2]
+  - nodes: [hub:port2, branch2:port2]
+  - nodes: [hub:port2, fortisase_pop:port2]
+  - nodes: [hub:port3, iam:eth0]
+  - nodes: [branch1:port3]
+  - nodes: [branch2:port3]


### PR DESCRIPTION
## Summary
- documente le laboratoire FortiSASE avec un README enrichi, une vue d'ensemble et une description détaillée de la topologie
- ajoute l'inventaire Ansible, les variables et les playbooks pour provisionner le hub, les branches, le POP FortiSASE et les services IAM
- fournit des scripts Bash pour initialiser l'environnement, appliquer les configurations et nettoyer les artefacts ainsi que des modèles de configuration

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d8404d28348332b24842e9d76c5001

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - End-to-end FortiSASE lab provisioning via Ansible, covering hub, branches, SASE POP, and IAM.
  - Predefined group variables for network, VPN/SD-WAN, DHCP, ZTNA tags, access policies, and authentication.
  - Playbooks for initialization and advanced configuration with reusable templates.
  - Helper scripts to initialize the environment, configure components, and clean outputs.

- Documentation
  - Expanded README with French overview and quick-start.
  - New lab overview and topology guides with architecture and network details.

- Chores
  - Added ignore patterns for virtual environments, build outputs, and bytecode caches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->